### PR TITLE
Add industrial_ci for package configuration testing

### DIFF
--- a/.ci.rosinstall
+++ b/.ci.rosinstall
@@ -1,0 +1,9 @@
+- git:
+    uri: https://github.com/rt-net/jnmouse_description.git
+    local-name: raspimouse_description
+    version: master
+
+- git:
+    uri: https://github.com/ryuichiueda/raspimouse_ros_2.git
+    local-name: raspimouse_ros_2
+    version: master

--- a/.ci.rosinstall
+++ b/.ci.rosinstall
@@ -1,6 +1,6 @@
 - git:
     uri: https://github.com/rt-net/jnmouse_description.git
-    local-name: raspimouse_description
+    local-name: jnmouse_description
     version: master
 
 - git:

--- a/.ci.rosinstall
+++ b/.ci.rosinstall
@@ -7,3 +7,13 @@
     uri: https://github.com/ryuichiueda/raspimouse_ros_2.git
     local-name: raspimouse_ros_2
     version: master
+
+- git:
+    uri: https://github.com/rt-net/raspimouse_sim.git
+    local-name: raspimouse_sim
+    version: master
+
+- git:
+    uri: https://github.com/rt-net/raspimouse_description.git
+    local-name: raspimouse_sim/raspimouse_description
+    version: master

--- a/.github/workflows/industrialci.yml
+++ b/.github/workflows/industrialci.yml
@@ -1,0 +1,33 @@
+name: industrial_ci
+
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+  schedule:
+    - cron: "0 1 * * 2" # Weekly on Tuesdays at 01:00(GMT)
+
+env:
+  UPSTREAM_WORKSPACE: .ci.rosinstall
+
+jobs:
+  industrial_ci:
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      matrix:
+        env:
+          - { ROS_DISTRO: melodic, ROS_REPO: main }
+        experimental: [false]
+        include:
+          - env: { ROS_DISTRO: melodic, ROS_REPO: testing }
+            experimental: true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: "ros-industrial/industrial_ci@master"
+        env: ${{ matrix.env }}

--- a/jnmouse_gazebo/CMakeLists.txt
+++ b/jnmouse_gazebo/CMakeLists.txt
@@ -11,7 +11,7 @@ install(PROGRAMS
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
-foreach(dir launch materials worlds)
+foreach(dir launch worlds)
   install(DIRECTORY ${dir}/
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir}
   )


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

ROSパッケージの構成チェックのためにindustrial_ciを導入します。
Gazeboを起動するlaunch等の簡単な構成ですが、package.xmlやCMakeLists.txtに問題がないか確認できるので導入します。
